### PR TITLE
fix(to-many-api-calls): add course store and integrate across pages

### DIFF
--- a/client/src/pages/AdminCourses.jsx
+++ b/client/src/pages/AdminCourses.jsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { axiosInstance } from "../utils/axios";
 import { Link, useNavigate } from "react-router";
+import { useCourseStore } from "../utils/store";
 
 export default function AdminCourses() {
   const navigate = useNavigate();
   const [adminCourses, setAdminCourses] = useState([]);
   const [loading, setLoading] = useState(true);
+  const setCourse = useCourseStore((state) => state.setCourse);
   const [error, setError] = useState("");
 
   async function getMyCourses() {
@@ -26,6 +28,11 @@ export default function AdminCourses() {
     } finally {
       setLoading(false);
     }
+  }
+
+  function viewCourse(courseId, course) {
+    setCourse(course);
+    navigate(`/course/${courseId}`);
   }
 
   useEffect(() => {
@@ -86,12 +93,12 @@ export default function AdminCourses() {
                   <div className="text-gray-900 font-medium">₹{course.price}</div>
                   <div className="text-sm text-gray-500">{course.creatorId.name}</div>
                 </div>
-                <Link
-                  to={`/course/${course._id}`}
+                <button
+                  onClick={() => viewCourse(course._id, course)}
                   className="block w-full bg-black text-white text-center py-2 rounded text-sm hover:bg-gray-800 transition-colors"
                 >
                   View Course
-                </Link>
+                </button>
               </div>
             </div>
           ))}

--- a/client/src/pages/Course.jsx
+++ b/client/src/pages/Course.jsx
@@ -1,15 +1,20 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { axiosInstance } from "../utils/axios";
+import { useCourseStore } from "../utils/store";
 
 export default function Course() {
   const { courseId } = useParams();
   const [course, setCourse] = useState({});
-
+  const currentCourse = useCourseStore((state) => state.course);
   const redirect = useNavigate();
 
   async function getCourseDetails() {
     try {
+      if (currentCourse._id === courseId) {
+        setCourse(currentCourse);
+        return;
+      }
       const response = await axiosInstance(`/courses/${courseId}`);
       setCourse(response.data.data);
     } catch (error) {

--- a/client/src/pages/ExploreCourses.jsx
+++ b/client/src/pages/ExploreCourses.jsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { axiosInstance } from "../utils/axios";
 import { useNavigate } from "react-router";
+import { useCourseStore } from "../utils/store";
 
 export default function ExploreCourses() {
   const [courses, setCourses] = useState([]);
   const [searchTerm, setSearchTerm] = useState("all");
-  
+
+  const setCourse = useCourseStore((state) => state.setCourse);
 
   const redirect = useNavigate();
 
@@ -23,8 +25,9 @@ export default function ExploreCourses() {
     }
   }
 
-  function handlePurchase(_, i) {
-    redirect(`/course/${courses[i]._id}`);
+  function handlePurchase(course) {
+    setCourse(course);
+    redirect(`/course/${course._id}`);
   }
 
   useEffect(() => {
@@ -68,7 +71,7 @@ export default function ExploreCourses() {
             <div
               key={i}
               className={`rounded-xl aspect-3/2 shadow-xl relative overflow-hidden cursor-pointer`}
-              onClick={(e) => handlePurchase(e, i)}
+              onClick={() => handlePurchase(course)}
             >
               <img
                 src={

--- a/client/src/pages/PurchaseCourses.jsx
+++ b/client/src/pages/PurchaseCourses.jsx
@@ -1,16 +1,22 @@
 import { useEffect, useState } from "react";
 import { axiosInstance } from "../utils/axios";
 import { useNavigate, useParams } from "react-router";
+import { useCourseStore } from "../utils/store";
 
 export default function PurchaseCourses() {
   const { courseId } = useParams();
   const [course, setCourse] = useState({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const currentCourse = useCourseStore((state) => state.course);
   const navigate = useNavigate();
 
   async function getCourseDetails() {
     try {
+      if (currentCourse._id === courseId) {
+        setCourse(currentCourse);
+        return;
+      }
       const response = await axiosInstance(`/courses/${courseId}`);
       setCourse(response.data.data);
     } catch (error) {
@@ -51,28 +57,36 @@ export default function PurchaseCourses() {
     <div className="min-h-screen w-full bg-white py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md mx-auto">
         <div className="bg-white p-8 rounded shadow-sm border border-gray-100">
-          <h2 className="text-2xl font-bold text-gray-900 mb-6">Complete Purchase</h2>
-          
+          <h2 className="text-2xl font-bold text-gray-900 mb-6">
+            Complete Purchase
+          </h2>
+
           <div className="mb-6">
-            <h3 className="text-lg font-medium text-gray-900 mb-2">{course.title}</h3>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              {course.title}
+            </h3>
             <p className="text-sm text-gray-600 mb-4">{course.description}</p>
-            
+
             <div className="flex items-baseline space-x-2 mb-4">
-              <span className="text-2xl font-medium text-gray-900">₹{course.price}</span>
+              <span className="text-2xl font-medium text-gray-900">
+                ₹{course.price}
+              </span>
               <span className="text-sm text-gray-500">one-time payment</span>
             </div>
 
             <div className="border-t border-gray-100 pt-4">
               <div className="flex items-center justify-between mb-4">
-                <span className="text-sm font-medium text-gray-900">Total Amount</span>
-                <span className="text-lg font-medium text-gray-900">₹{course.price}</span>
+                <span className="text-sm font-medium text-gray-900">
+                  Total Amount
+                </span>
+                <span className="text-lg font-medium text-gray-900">
+                  ₹{course.price}
+                </span>
               </div>
             </div>
           </div>
 
-          {error && (
-            <div className="mb-4 text-sm text-red-600">{error}</div>
-          )}
+          {error && <div className="mb-4 text-sm text-red-600">{error}</div>}
 
           <button
             onClick={handlePurchase}

--- a/client/src/pages/UserCourses.jsx
+++ b/client/src/pages/UserCourses.jsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { axiosInstance } from "../utils/axios";
 import { useNavigate } from "react-router";
+import { useCourseStore } from "../utils/store";
 
 export default function UserCourses() {
   const [myCourses, setMyCourses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const setCourse = useCourseStore((state) => state.setCourse);
   const navigate = useNavigate();
 
   async function getMyCourses() {
@@ -26,6 +28,11 @@ export default function UserCourses() {
     } finally {
       setLoading(false);
     }
+  }
+
+  function viewCourse(courseId, course) {
+    setCourse(course);
+    navigate(`/course/${courseId}`);
   }
 
   useEffect(() => {
@@ -94,7 +101,7 @@ export default function UserCourses() {
                 </div>
 
                 <button
-                  onClick={() => navigate(`/course/${course._id}`)}
+                  onClick={() => viewCourse(course._id, course)}
                   className="mt-4 w-full bg-black text-white px-4 py-2 rounded text-sm hover:bg-gray-800 transition-colors"
                 >
                   View Course

--- a/client/src/utils/store.js
+++ b/client/src/utils/store.js
@@ -14,3 +14,15 @@ export const useUserStore = create(
     }
   )
 );
+export const useCourseStore = create(
+  persist(
+    (set) => ({
+      currentCourse: null,
+      setCourse: (course) => set({ course: { ...course } }),
+    }),
+    {
+      name: "course-storage",
+      getStorage: () => localStorage,
+    }
+  )
+);


### PR DESCRIPTION
Fixes #3 

Implement a Zustand store for course state management to persist course data between page navigations. The store is integrated in Course, ExploreCourses, UserCourses, AdminCourses, and PurchaseCourses pages to avoid redundant API calls when navigating back to a previously viewed course.
